### PR TITLE
Fix issues of 'bucket bound method MrrcConfig.get_aws_bucket' and 'no attribute _MrrcConfig__mrrc_configs'

### DIFF
--- a/mrrc/cmd/command.py
+++ b/mrrc/cmd/command.py
@@ -195,7 +195,7 @@ def __get_bucket() -> str:
         logger.info("AWS bucket '%s' found in system environment var '%s'"
                     ", will use it for following process", bucket, MRRC_BUCKET)
         return bucket
-    return mrrc_config().get_aws_bucket
+    return mrrc_config().get_aws_bucket()
 
 
 @group()

--- a/mrrc/config.py
+++ b/mrrc/config.py
@@ -37,6 +37,8 @@ class MrrcConfig(object):
     in $HOME/.mrrc/ folder by default.
     """
 
+    __mrrc_configs = dict()
+
     def __init__(self, data: ConfigParser):
         try:
             self.__mrrc_configs = dict(data.items(SECTION_MRRC))


### PR DESCRIPTION
Just as the title, I found them blocks the process when trying to get config from the HOME mrrc-uploader.conf.
@ligangty please have a look, thanks.